### PR TITLE
Bugfix for converting optional attribute from new metadata for ccpp_prebuild.py

### DIFF
--- a/scripts/metadata_parser.py
+++ b/scripts/metadata_parser.py
@@ -158,7 +158,7 @@ def read_new_metadata(filename, module_name, table_name, scheme_name = None, sub
                       container     = container,
                       kind          = new_var.get_prop_value('kind'),
                       intent        = new_var.get_prop_value('intent'),
-                      optional      = new_var.get_prop_value('optional'),
+                      optional      = 'T' if new_var.get_prop_value('optional') else 'F',
                       )
             # Set rank using integer-setter method
             var.rank = rank


### PR DESCRIPTION
scripts/metadata_parser.py: bugfix for converting optional attribute from new to old metadata

The new metadata parser stores the optional attribute as (Python) logicals True or False, but ccpp_prebuild.py expects strings ('T', 't', 'F', 'f') as in the old metadata format.

Associated PRs:
https://github.com/NOAA-GSD/ccpp-framework/pull/1
https://github.com/NOAA-GSD/ccpp-physics/pull/15
https://github.com/NOAA-GSD/fv3atm/pull/12
https://github.com/NOAA-GSD/ufs-weather-model/pull/10